### PR TITLE
installer_data: Update to Fedora Asahi Remix 44 202607221600

### DIFF
--- a/data/installer_data.json
+++ b/data/installer_data.json
@@ -5,7 +5,7 @@
             "default_os_name": "Fedora Linux with KDE Plasma",
             "boot_object": "m1n1.bin",
             "next_object": "m1n1/boot.bin",
-            "package": "https://asahilinux-fedora.b-cdn.net/os/fedora-44-kde-202604271600.zip",
+            "package": "https://asahilinux-fedora.b-cdn.net/os/fedora-44-kde-202607221600.zip",
             "icon": "fedora.icns",
             "supported_fw": [
                 "12.3",
@@ -22,7 +22,7 @@
                     "type": "EFI",
                     "size": "524288000B",
                     "format": "fat",
-                    "volume_id": "0x2fa765ab",
+                    "volume_id": "0x195fb43a",
                     "copy_firmware": true,
                     "copy_installer_data": true,
                     "source": "esp"
@@ -36,7 +36,7 @@
                 {
                     "name": "Root",
                     "type": "Linux",
-                    "size": "14119055360B",
+                    "size": "14248030208B",
                     "expand": true,
                     "image": "root.img"
                 }
@@ -47,7 +47,7 @@
             "default_os_name": "Fedora Linux with GNOME",
             "boot_object": "m1n1.bin",
             "next_object": "m1n1/boot.bin",
-            "package": "https://asahilinux-fedora.b-cdn.net/os/fedora-44-gnome-202604271600.zip",
+            "package": "https://asahilinux-fedora.b-cdn.net/os/fedora-44-gnome-202607221600.zip",
             "icon": "fedora.icns",
             "supported_fw": [
                 "12.3",
@@ -64,7 +64,7 @@
                     "type": "EFI",
                     "size": "524288000B",
                     "format": "fat",
-                    "volume_id": "0x6f6a6df5",
+                    "volume_id": "0x92b9ca47",
                     "copy_firmware": true,
                     "copy_installer_data": true,
                     "source": "esp"
@@ -78,7 +78,7 @@
                 {
                     "name": "Root",
                     "type": "Linux",
-                    "size": "10976473088B",
+                    "size": "10932432896B",
                     "expand": true,
                     "image": "root.img"
                 }
@@ -89,7 +89,7 @@
             "default_os_name": "Fedora Linux Server",
             "boot_object": "m1n1.bin",
             "next_object": "m1n1/boot.bin",
-            "package": "https://asahilinux-fedora.b-cdn.net/os/fedora-44-server-202604271600.zip",
+            "package": "https://asahilinux-fedora.b-cdn.net/os/fedora-44-server-202607221600.zip",
             "icon": "fedora.icns",
             "supported_fw": [
                 "12.3",
@@ -103,7 +103,7 @@
                     "type": "EFI",
                     "size": "524288000B",
                     "format": "fat",
-                    "volume_id": "0x379693b5",
+                    "volume_id": "0x2d29ccb0",
                     "copy_firmware": true,
                     "copy_installer_data": true,
                     "source": "esp"
@@ -117,7 +117,7 @@
                 {
                     "name": "Root",
                     "type": "Linux",
-                    "size": "4521439232B",
+                    "size": "4456427520B",
                     "expand": true,
                     "image": "root.img"
                 }
@@ -128,7 +128,7 @@
             "default_os_name": "Fedora Linux Minimal",
             "boot_object": "m1n1.bin",
             "next_object": "m1n1/boot.bin",
-            "package": "https://asahilinux-fedora.b-cdn.net/os/fedora-44-minimal-202604271600.zip",
+            "package": "https://asahilinux-fedora.b-cdn.net/os/fedora-44-minimal-202607221600.zip",
             "icon": "fedora.icns",
             "supported_fw": [
                 "12.3",
@@ -142,7 +142,7 @@
                     "type": "EFI",
                     "size": "524288000B",
                     "format": "fat",
-                    "volume_id": "0xf4ee033b",
+                    "volume_id": "0xc5db768e",
                     "copy_firmware": true,
                     "copy_installer_data": true,
                     "source": "esp"
@@ -156,7 +156,7 @@
                 {
                     "name": "Root",
                     "type": "Linux",
-                    "size": "4241469440B",
+                    "size": "4173312000B",
                     "expand": true,
                     "image": "root.img"
                 }


### PR DESCRIPTION
Update install images to newer build with a macOS 27 safe macsmc_power driver to prevent random power offs due to misidentified emergency battery state.